### PR TITLE
Check for IPV6 first

### DIFF
--- a/src/detector.js
+++ b/src/detector.js
@@ -28,7 +28,7 @@ class Detector {
   }
 
   _handleCandidate(info) {
-    for (let reg of [IPV4_REGEX, IPV6_REGEX]) {
+    for (let reg of [IPV6_REGEX, IPV4_REGEX]) {
       const matches = reg.exec(info);
       if (matches) {
         this._push(matches[0], reg === IPV6_REGEX);


### PR DESCRIPTION
Check for IPV6 first, since the IPV4 regex will match against something like `candidate:4231669940 1 udp 1677732095 2001:ac8:7d:19:16::1 60562 typ srflx raddr 0.0.0.0 rport 0 generation 0 ufrag tbUJ network-cost 999` the `0.0.0.0` part, so in the end we don't get the IPV6 address.